### PR TITLE
Fix: redis 읽기 전용 오류 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
 
   redis:
     image: redis:7.2.4
+    restart: always
+    command: redis-server --replicaof no one --maxmemory-policy noeviction
     ports:
       - "6379:6379"
     networks:


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #24 번 이슈와 관련이 있습니다.

## ✨ 작업내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- redis에서 replica 구조로 인해 master redis가 아닌 redis slave redis에 접근하는 읽기 전용 참조가 일어나 channel layers 통신과정에서 오류가 발생했습니다.
- 따라서, docker-compose file의 `command: redis-server --replicaof no one --maxmemory-policy noeviction` 명령어를 통해 해결하였습니다.
- replicaof no no one 명령어는 항상 master redis만 참조하겠다는 의미입니다.
- maxmemory-policy noeviction 명령어는 메모리 초과로 인해 slave redis를 참조하는 경우를 막는 명령어입니다.

### 스크린샷 (선택)
<!--스크린샷을 남겨서 PR에 도움을 줄 수 있다면 스크린샷을 넣어주시는 것을 권장드립니다.-->

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
